### PR TITLE
Add bionic stack to buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -29,3 +29,6 @@ api = "0.2"
 
 [[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"
+
+[[stacks]]
+  id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
Adds bionic stack to the `[[stacks]]` section as it is listed by the dependencies as a supported stack.